### PR TITLE
feat: support for compile & extract options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Require sass files and get an object containing extracted sass variables. Suppor
 
 **Note** that this is an early prototype.
 
+## Options
+
+### compileOptions
+
+Same as `node-sass` options, defaults to `{}`.
+
+### extractOptions
+
+Same as that of `sass-extract`, defaults to `{ plugins: ['minimal'] }`.
+
 ## Install
 
 You need to install the sass compiler, sass-extract and the plugin since they are all [peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).

--- a/examples/basic/.babelrc
+++ b/examples/basic/.babelrc
@@ -1,3 +1,4 @@
 {
+  "presets": ["env"],
   "plugins": ["sass-extract"]
 }

--- a/examples/basic/dist/test.js
+++ b/examples/basic/dist/test.js
@@ -1,24 +1,14 @@
-const styleVars1 = {
+'use strict';
+
+var styleVars1 = {
   'global': {
-    '$a': {
-      'type': 'SassNumber',
-      'value': 123,
-      'unit': 'px',
-      'sources': ['/Users/John/code/babel-plugin-sass-extract/examples/basic/test.scss'],
-      'expressions': ['123px']
-    }
+    '$a': '123px'
   }
 };
 
-const styleVars2 = {
+var styleVars2 = {
   'global': {
-    '$a': {
-      'type': 'SassNumber',
-      'value': 123,
-      'unit': 'px',
-      'sources': ['/Users/John/code/babel-plugin-sass-extract/examples/basic/test.scss'],
-      'expressions': ['123px']
-    }
+    '$a': '123px'
   }
 };
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -7,14 +7,16 @@
     "start": "babel --out-dir ./dist test.js && node ./dist/test.js"
   },
   "author": "John Granström <granstrom.john@gmail.com>",
+  "contributors": [
+    "James G. Kim <jgkim@jayg.org>"
+  ],
   "license": "MIT",
-  "dependencies": {
+  "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.24.1",
-    "node-sass": "^4.5.3",
-    "sass-extract": "^0.5.0"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.24.1"
+    "babel-plugin-sass-extract": "^0.1.0",
+    "babel-preset-env": "^1.6.1",
+    "node-sass": "^4.7.2",
+    "sass-extract": "^2.1.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,21 @@ function getRequiredFilePath(requiringPath, requiredPath) {
   return path.posix.resolve(path.posix.join(path.posix.dirname(requiringPath), requiredPath));
 }
 
-function extractVariables(absolutePath, compiledFiles, options) {
+function extractVariables(absolutePath, compiledFiles, options = {}) {
   let vars;
   if(compiledFiles[absolutePath]) {
     vars = compiledFiles[absolutePath];
   } else {
-    vars = compiledFiles[absolutePath] = sassExtract.renderSync(Object.assign({}, options, { file: absolutePath })).vars;
+    const compileOptions = Object.assign({}, options.compileOptions || {}, { file: absolutePath });
+    const extractOptions = Object.assign({}, options.extractOptions || { plugins: ['minimal'] });
+
+    (extractOptions.plugins || []).forEach(plugin => {
+      if (['serialize', 'compact', 'minimal', 'filter'].some(name => name === plugin)) {
+        require(`sass-extract/lib/plugins/${plugin}`);
+      }
+    });
+
+    vars = compiledFiles[absolutePath] = sassExtract.renderSync(compileOptions, extractOptions).vars;
   }
 
   return vars;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "repository": "jgranstrom/babel-plugin-sass-extract",
   "author": "John Granström <granstrom.john@gmail.com>",
+  "contributors": [
+    "James G. Kim <jgkim@jayg.org>"
+  ],
   "keywords": [
     "babel",
     "plugin",
@@ -26,7 +29,7 @@
     "node": ">=4"
   },
   "peerDependencies": {
-    "sass-extract": "^0.5.0"
+    "sass-extract": "^2.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -39,6 +42,6 @@
     }
   },
   "dependencies": {
-    "babel-literal-to-ast": "^0.1.2"
+    "babel-literal-to-ast": "^1.0.0"
   }
 }


### PR DESCRIPTION
I've tried to add support for `compileOptions` and `extractOptions`, making it default to use the `minimal` plugin.